### PR TITLE
Wrong method signature

### DIFF
--- a/src/main/java/net/eusashead/iot/mqtt/paho/ConnectObservableFactory.java
+++ b/src/main/java/net/eusashead/iot/mqtt/paho/ConnectObservableFactory.java
@@ -60,7 +60,7 @@ public class ConnectObservableFactory extends BaseObservableFactory {
     public Observable<Void> create() {
         return Observable.fromEmitter(observer -> {
             try {
-                client.connect(options, new ConnectActionListener(observer));
+                client.connect(options, null, new ConnectActionListener(observer));
             } catch (MqttException exception) {
                 if (LOGGER.isLoggable(Level.SEVERE)) {
                     LOGGER.log(Level.SEVERE, exception.getMessage(), exception);

--- a/src/test/java/net/eusashead/iot/mqtt/paho/ConnectObservableFactoryTest.java
+++ b/src/test/java/net/eusashead/iot/mqtt/paho/ConnectObservableFactoryTest.java
@@ -55,7 +55,7 @@ public class ConnectObservableFactoryTest {
         final Observable<Void> obs = factory.create();
         Assert.assertNotNull(obs);
         obs.subscribe();
-        Mockito.verify(client).connect(Mockito.same(options),
+        Mockito.verify(client).connect(Mockito.same(options), Mockito.isNull(),
                 actionListener.capture());
         Assert.assertTrue(actionListener.getValue() instanceof ConnectObservableFactory.ConnectActionListener);
     }
@@ -65,7 +65,7 @@ public class ConnectObservableFactoryTest {
         expectedException.expectCause(isA(MqttException.class));
         final MqttConnectOptions options = Mockito.mock(MqttConnectOptions.class);
         final IMqttAsyncClient client = Mockito.mock(IMqttAsyncClient.class);
-        Mockito.when(client.connect(Mockito.same(options),
+        Mockito.when(client.connect(Mockito.same(options), Mockito.isNull(),
                 Mockito.any(ConnectObservableFactory.ConnectActionListener.class)))
                 .thenThrow(new MqttException(MqttException.REASON_CODE_CLIENT_CONNECTED));
         final ConnectObservableFactory factory = new ConnectObservableFactory(client, options);


### PR DESCRIPTION
The Paho connection method was invoking the wrong method signature, causing the MQTT options not to be used correctly.